### PR TITLE
Fix: remove transition-colors from kt-table row

### DIFF
--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -13,7 +13,7 @@
 		caption-side: bottom;
 
 		tr {
-			@apply border-b border-border transition-colors;
+			@apply border-b border-border;
 		}
 
 		caption {


### PR DESCRIPTION
The `transition-colors` property in **.kt-table** is causing a noticeable flashing/flickering effect; when switching from light to dark mode. This issue doesn't appear in previous Metronic versions or other KtUI components. 


https://github.com/user-attachments/assets/b76f4f0b-526b-464c-829c-1c50c34b2a6e


https://ktui.io/docs/datatable

 