### PR TITLE
Add styles.css to exports and update README import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To enable automated dark mode support add below Tailwind variant in your Tailwin
 Include KTUI styles in your Tailwind entry file `style.css`:
 
 ```css
-@import "./node_modules/ktui/styles.css";
+@import "@keenthemes/ktui/styles.css";
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
 	"types": "lib/esm/index.d.ts",
 	"main": "lib/cjs/index.js",
 	"module": "lib/esm/index.js",
+	"exports": {
+		".": {
+			"import": "./lib/esm/index.js",
+			"require": "./lib/cjs/index.js"
+		},
+		"./styles.css": "./styles.css"
+	},
 	"license": "MIT",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
The `styles.css` file was added to the export map in `package.json` for better module resolution. Additionally, the README was updated to reflect the correct import path for the styles, improving usability and consistency.