### PR TITLE
KTDataTable: Refactor cell rendering to support HTMLElement results.

### DIFF
--- a/src/components/datatable/datatable.ts
+++ b/src/components/datatable/datatable.ts
@@ -981,10 +981,11 @@ export class KTDataTable<T extends KTDataTableDataInterface>
 
 						if (typeof columnDef.render === 'function') {
 							const result = columnDef.render.call(this, item[key], item, this);
-							if (result instanceof HTMLElement) {
+							if (result instanceof HTMLElement || result instanceof DocumentFragment) {
 								td.appendChild(result);
-							} else if (typeof result === 'string') {
-								td.innerHTML = result;
+							}
+							else if (typeof result === 'string') {
+								td.innerHTML = result as string;
 							}
 						} else {
 							td.textContent = item[key] as string;

--- a/src/components/datatable/datatable.ts
+++ b/src/components/datatable/datatable.ts
@@ -980,12 +980,12 @@ export class KTDataTable<T extends KTDataTableDataInterface>
 						}
 
 						if (typeof columnDef.render === 'function') {
-							td.innerHTML = columnDef.render.call(
-								this,
-								item[key] as string,
-								item,
-								this,
-							) as string;
+							const result = columnDef.render.call(this, item[key], item, this);
+							if (result instanceof HTMLElement) {
+								td.appendChild(result);
+							} else if (typeof result === 'string') {
+								td.innerHTML = result;
+							}
 						} else {
 							td.textContent = item[key] as string;
 						}


### PR DESCRIPTION
Updated the `render` function logic to allow appending `HTMLElement` results directly to table cells. This improves flexibility, enabling both string and DOM element outputs for custom render functions.