### PR TITLE
enables step cancellation based on async validation in change event handlers

### DIFF
--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -43,10 +43,24 @@ export default class KTComponent {
 		KTData.set(this._element, this._name, this);
 	}
 
-	protected _fireEvent(eventType: string, payload: object = null): void {
-		this._events.get(eventType)?.forEach((callable) => {
-			callable(payload);
-		});
+	protected async _fireEvent(eventType: string, payload: object = null): Promise<void> {
+		const callbacks = this._events.get(eventType);
+
+		if ((callbacks instanceof Map) == false) {
+			return;
+		}
+
+		await Promise.all(
+			Array.from(
+				callbacks.values()
+			).filter((callable) => {
+				return typeof callable === 'function';
+			}).map((callable) => {
+				return Promise.resolve(
+					callable(payload)
+				);
+			})
+		);
 	}
 
 	protected _dispatchEvent(eventType: string, payload: object = null): void {

--- a/src/components/stepper/stepper.ts
+++ b/src/components/stepper/stepper.ts
@@ -131,12 +131,12 @@ export class KTStepper extends KTComponent implements KTStepperInterface {
 		return elements;
 	}
 
-	protected _go(step: number): void {
+	protected async _go(step: number): Promise<void> {
 		if (step === this._activeStep || step > this._getTotalSteps() || step < 0)
 			return;
 
 		const payload = { step: step, cancel: false };
-		this._fireEvent('change', payload);
+		await this._fireEvent('change', payload);
 		this._dispatchEvent('change', payload);
 		if (payload.cancel === true) {
 			return;


### PR DESCRIPTION

Hello,

Previously, the change event was executed synchronously and could not wait for the fetch response. By implementing async/await, the request is now processed asynchronously, and in case of failure, setting **detail.cancel = true** prevents proceeding to the next step.

example code :

```
const stepper = new KTStepper(
    document.querySelector('#my_stepper')
);

stepper.on('change', async (detail) => {
  const response = await fetch('/some-url', { method: 'POST' });
  const data = await response.json();

  if (!data.success) {
    detail.cancel = true;
  }
});
```
