### PR TITLE
fix(components): Enhance clearAll to remove containers and clear cont…

### DIFF
--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -515,10 +515,19 @@ export class KTToast extends KTComponent implements KTToastInterface {
 	/**
 	 * Close and remove all active toasts.
 	 */
-	static clearAll() {
+	static clearAll(clearContainers: boolean = false) {
 		for (const id of Array.from(this.toasts.keys())) {
 			console.log('clearAll:', id);
 			this.close(id);
+		}
+		if (clearContainers) {
+			// Remove all containers from the DOM.
+			this.containerMap.forEach((container, position) => {
+				container.remove();
+				console.log('clearAll: removed container for position', position);
+			});
+			// Clear containerMap to prevent stale references.
+			this.containerMap.clear();
 		}
 	}
 


### PR DESCRIPTION
### Summary
This PR enhances the `KTToast.clearAll` method to remove all toast containers from the DOM and clear the `containerMap`. This prevents stale container references, which can cause toasts to not display when containers are removed externally (e.g., in SPA navigation or Turbo-driven apps).

### Changes
- Updated `KTToast.clearAll` to iterate over `containerMap`, remove each container from the DOM, and clear the map.
- Added logging for container removals for debugging.

### Motivation
In frameworks like Rails with Hotwire (Turbo), DOM elements may be removed during navigation (e.g., via `turbo:before-cache`), but `containerMap` retains stale references, preventing new toasts from rendering. This change ensures a clean slate after `clearAll` is called.

### Checklist
- [x] Code follows project style guidelines.
- [x] Tested changes locally.