### PR TITLE
fix(interface): correct KTDataTableConfigInterface render method return type

### DIFF
--- a/src/components/datatable/types.ts
+++ b/src/components/datatable/types.ts
@@ -90,7 +90,7 @@ export interface KTDataTableConfigInterface {
 				item: KTDataTableDataInterface[keyof KTDataTableDataInterface] | string,
 				data: KTDataTableDataInterface,
 				context: KTDataTableInterface,
-			) => string;
+			) => string | HTMLElement | DocumentFragment;
 			checkbox?: boolean;
 			createdCell?: (
 				cell: HTMLTableCellElement,
@@ -192,9 +192,13 @@ export interface KTDataTableCheckConfigInterface {
 
 export interface KTDataTableCheckInterface {
 	toggle(): void;
+
 	check(): void;
+
 	uncheck(): void;
+
 	isChecked(): boolean;
+
 	getChecked(): string[];
 }
 


### PR DESCRIPTION
The render method already supports multiple return types (`string`, `HTMLElement`, and `DocumentFragment`), but the interface previously declared only `string`. This update aligns the interface definition with the actual supported types, ensuring proper type safety and consistency.