### PR TITLE
refactor(select): improve selection preservation and modal handling

### DIFF
--- a/examples/select/modal-positioning-test.html
+++ b/examples/select/modal-positioning-test.html
@@ -240,14 +240,15 @@
 			</div>
 		</div>
 
-		<script>
-			document.addEventListener('DOMContentLoaded', function () {
-				const form = document.getElementById('testForm');
-				const resultsDiv = document.getElementById('results');
-				const remoteSelectEl = document.querySelector(
-					'select[name="remoteSelect"]',
-				);
+	<script>
+		document.addEventListener('DOMContentLoaded', function () {
+			const form = document.getElementById('testForm');
+			const resultsDiv = document.getElementById('results');
+			const remoteSelectEl = document.querySelector(
+				'select[name="remoteSelect"]',
+			);
 
+			if (form) {
 				form.addEventListener('submit', function (e) {
 					e.preventDefault();
 					resultsDiv.innerHTML = '';
@@ -282,8 +283,9 @@
 						: 'FAIL: Remote select missing';
 					resultsDiv.appendChild(verdict);
 				});
+			}
 
-				const modal = document.getElementById('modal-remote');
+			const modal = document.getElementById('modal-remote');
 				const remoteSelectInModal = document.getElementById(
 					'remoteSelectInModal',
 				);


### PR DESCRIPTION
- Enhanced the KTSelect component to prevent browser auto-selection when a placeholder is configured, ensuring a cleaner user experience.
- Updated the `update` and `refresh` methods to preserve selected options when fetching new remote data, improving the component's usability.
- Adjusted the example HTML to ensure proper initialization of the KTSelect components, enhancing robustness during page load.