### PR TITLE
feat: Add global cleanup method for Hotwire/Turbo compatibility

### DIFF
--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -189,7 +189,7 @@ export class KTAccordion extends KTComponent implements KTAccordionInterface {
 			return KTData.get(element, 'accordion') as KTAccordion;
 		}
 
-		if (element.getAttribute('data-kt-accordion-initialized') === 'true') {
+		if (element.getAttribute('data-kt-accordion')) {
 			return new KTAccordion(element);
 		}
 

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -170,4 +170,16 @@ export default class KTComponent {
 		if (!this._element) return null;
 		return this._element;
 	}
+
+	public static cleanup(): void {
+		const map = KTData.getElementMap();
+
+		map.forEach((components) => {
+			Array.from(components.values()).forEach((component) => {
+				if (component && typeof (component as any).dispose === 'function') {
+					(component as any).dispose();
+				}
+			});
+		});
+	}
 }

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -272,7 +272,7 @@ export class KTDrawer extends KTComponent implements KTDrawerInterface {
 			return KTData.get(element, 'drawer') as KTDrawer;
 		}
 
-		if (element.getAttribute('data-kt-drawer-initialized') === 'true') {
+		if (element.getAttribute('data-kt-drawer')) {
 			return new KTDrawer(element);
 		}
 

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -226,6 +226,11 @@ export class KTDropdown extends KTComponent implements KTDropdownInterface {
 		});
 	}
 
+	public dispose(): void {
+		this._destroyPopper();
+		super.dispose();
+	}
+
 	protected _initPopper(): void {
 		const isRtl = KTDom.isRTL();
 		let reference: HTMLElement;
@@ -364,12 +369,11 @@ export class KTDropdown extends KTComponent implements KTDropdownInterface {
 
 	// Static Methods
 	public static getElement(reference: HTMLElement): HTMLElement {
-		if (reference && reference.hasAttribute('data-kt-dropdown-initialized'))
+		if (reference && reference.hasAttribute('data-kt-dropdown'))
 			return reference;
 
 		const findElement =
-			reference &&
-			(reference.closest('[data-kt-dropdown-initialized]') as HTMLElement);
+			reference && (reference.closest('[data-kt-dropdown]') as HTMLElement);
 		if (findElement) return findElement;
 
 		if (
@@ -392,7 +396,7 @@ export class KTDropdown extends KTComponent implements KTDropdownInterface {
 			return KTData.get(element, 'dropdown') as KTDropdown;
 		}
 
-		if (element.getAttribute('data-kt-dropdown-initialized') === 'true') {
+		if (element.getAttribute('data-kt-dropdown')) {
 			return new KTDropdown(element);
 		}
 

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -237,6 +237,13 @@ export class KTTooltip extends KTComponent implements KTTooltipInterface {
 		});
 	}
 
+	public dispose(): void {
+		if (this._popper) {
+			this._popper.destroy();
+		}
+		super.dispose();
+	}
+
 	protected _handleContainer(): void {
 		if (this._getOption('container')) {
 			if (this._getOption('container') === 'body') {

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 by Keenthemes Inc
  */
 
-const KTElementMap = new Map();
+const KTElementMap: Map<HTMLElement, Map<string, unknown>> = new Map();
 
 const KTData = {
 	set(element: HTMLElement, key: string, value: unknown): void {
@@ -40,6 +40,10 @@ const KTData = {
 		if (valueMap.size === 0) {
 			KTElementMap.delete(element);
 		}
+	},
+
+	getElementMap(): Map<HTMLElement, Map<string, unknown>> {
+		return KTElementMap;
 	},
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 import KTDom from './helpers/dom';
 import KTUtils from './helpers/utils';
 import KTEventHandler from './helpers/event-handler';
+import KTComponent from './components/component';
 import { KTDropdown } from './components/dropdown';
 import { KTModal } from './components/modal';
 import { KTDrawer } from './components/drawer';
@@ -74,6 +75,35 @@ const KTComponents = {
 		KTSelect.init();
 		KTToast.init();
 	},
+	cleanup(): void {
+		KTComponent.cleanup();
+
+		const flags = [
+			'KT_DROPDOWN_INITIALIZED',
+			'KT_MODAL_INITIALIZED',
+			'KT_DRAWER_INITIALIZED',
+			'KT_DISMISS_INITIALIZED',
+			'KT_TABS_INITIALIZED',
+			'KT_ACCORDION_INITIALIZED',
+			'KT_SCROLLSPY_INITIALIZED',
+			'KT_SCROLLABLE_INITIALIZED',
+			'KT_SCROLLTO_INITIALIZED',
+			'KT_STICKY_INITIALIZED',
+			'KT_REPARENT_INITIALIZED',
+			'KT_TOGGLE_INITIALIZED',
+			'KT_TOOLTIP_INITIALIZED',
+			'KT_STEPPER_INITIALIZED',
+			'KT_THEME_SWITCH_INITIALIZED',
+			'KT_IMAGE_INPUT_INITIALIZED',
+			'KT_TOGGLE_PASSWORD_INITIALIZED',
+		];
+
+		flags.forEach((flag) => {
+			if ((window as any)[flag]) {
+				(window as any)[flag] = false;
+			}
+		});
+	},
 };
 
 declare global {
@@ -104,6 +134,13 @@ declare global {
 		KTToast: typeof KTToast;
 		KTComponents: typeof KTComponents;
 	}
+}
+
+if (typeof window !== 'undefined') {
+	window.KTComponents = KTComponents;
+	window.KTUtils = KTUtils;
+	window.KTDom = KTDom;
+	window.KTEventHandler = KTEventHandler;
 }
 
 export default KTComponents;


### PR DESCRIPTION
## Summary

This PR adds a global component cleanup mechanism to support Hotwire (Turbo), Turbolinks, and other SPA frameworks that cache or dynamically replace page content.

## Problem

When using KTUI with Hotwire Turbo or similar frameworks, navigating between pages leaves component instances attached to detached/cached DOM elements, causing:

1. **Memory leaks** - Component references retained in the internal data map
2. **Broken interactions** - Events not re-binding when using browser back/forward navigation (Turbo Restore)
3. **Initialization failures** - Components not properly re-initializing on cached pages

- Add static `cleanup()` method to KTComponent base class
- Expose `KTComponents.cleanup()` for global component cleanup
- Fix `getInstance()` methods to check original data attributes
- Add `dispose()` override in KTDropdown to cleanup Popper instances
- Reset global initialization flags on cleanup
- Export `getElementMap()` in KTData helper for cleanup iteration

Fixes component interaction issues when navigating with Hotwire Turbo, Turbolinks, or other SPA frameworks that cache/replace page content.